### PR TITLE
Product filters

### DIFF
--- a/js/pagination.js
+++ b/js/pagination.js
@@ -10,6 +10,16 @@ function paginate() {
   paginationList.innerHTML = ""
 
   const productsArray = Array.from(productContainer.children)
+
+  if (!productsArray.length) {
+    const noProductsPlaceholder = document.createElement("p")
+    noProductsPlaceholder.appendChild(
+      document.createTextNode("No products available at the moment")
+    )
+    paginationList.appendChild(noProductsPlaceholder)
+    return
+  }
+
   const pageAmount = Math.ceil(productsArray.length / PRODUCTS_PER_PAGE)
 
   let currentPage

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -60,8 +60,8 @@ function paginate() {
   openPage(1)()
 }
 
-const categoryNames = []
-const brandNames = []
+const categoryNames = new Set()
+const brandNames = new Set()
 const activeFilters = {
   categories: [],
   brands: [],
@@ -70,8 +70,14 @@ const activeFilters = {
 for (const {
   dataset: {categories, brands},
 } of productContainer.children) {
-  categories?.length && categoryNames.push(...categories.split(/ /))
-  brands?.length && brandNames.push(...brands.split(/ /))
+  categories
+    ?.split(/ /)
+    .filter((cn) => cn)
+    .map(categoryNames.add, categoryNames)
+  brands
+    ?.split(/ /)
+    .filter((bn) => bn)
+    .map(brandNames.add, brandNames)
 }
 
 function filter({target}) {
@@ -90,16 +96,22 @@ function filter({target}) {
     for (const product of Object.values(productStore))
       productContainer.appendChild(product)
   else {
-    const matchingProducts = Object.values(productStore).filter(({dataset}) =>
-      dataset.categories
-        ?.split(/ /)
-        .some(
-          (category) =>
-            activeFilters.categories.includes(category) ||
-            dataset.brands
-              ?.split(/ /)
-              .some((brand) => activeFilters.brands.includes(brand))
-        )
+    const matchingProducts = Object.values(productStore).filter(
+      ({dataset}) =>
+        dataset.categories
+          ?.split(/ /)
+          .some(
+            (category) =>
+              !activeFilters.categories.length ||
+              activeFilters.categories.includes(category)
+          ) &&
+        dataset.brands
+          ?.split(/ /)
+          .some(
+            (brand) =>
+              !activeFilters.brands.length ||
+              activeFilters.brands.includes(brand)
+          )
     )
     for (const matchingProduct of matchingProducts) {
       productContainer.appendChild(matchingProduct)
@@ -137,11 +149,11 @@ function createFilterCheckbox(type, name) {
   return listItem
 }
 
-for (const categoryName of categoryNames) {
+for (const categoryName of [...categoryNames].sort()) {
   categoryList.appendChild(createFilterCheckbox("categories", categoryName))
 }
 
-for (const brandName of brandNames) {
+for (const brandName of [...brandNames].sort()) {
   brandList.appendChild(createFilterCheckbox("brands", brandName))
 }
 

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -1,54 +1,148 @@
 const PRODUCTS_PER_PAGE = 5 // adjust to your liking
 
-const productContainer = document.querySelector("div.product-layout")
-const productsArray = Object.values(productContainer.children)
-const pageButtonList = document.querySelector("ul.pagination")
+const productContainer = document.getElementById("product-container")
+const productStore = {...productContainer.children}
+const paginationList = document.getElementById("pagination-list")
+const categoryList = document.getElementById("category-list")
+const brandList = document.getElementById("brand-list")
 
-const pageAmount = Math.ceil(productsArray.length / PRODUCTS_PER_PAGE)
+function paginate() {
+  paginationList.innerHTML = ""
 
-let currentPage
+  const productsArray = Array.from(productContainer.children)
+  const pageAmount = Math.ceil(productsArray.length / PRODUCTS_PER_PAGE)
 
-function openPage(pageNumber) {
-  return function () {
-    productContainer.innerHTML = ""
-    currentPage = pageNumber
-    const productsForCurrentPage = productsArray.slice(
-      PRODUCTS_PER_PAGE * (currentPage - 1),
-      PRODUCTS_PER_PAGE * (currentPage - 1) + PRODUCTS_PER_PAGE
-    )
-    for (const product of productsForCurrentPage)
-      productContainer.appendChild(product)
-    pageButtonList
-      .querySelectorAll(":not(:last-child):not(:nth-last-child(2))")
-      .forEach((el) => el.removeAttribute("class"))
-    pageButtonList
-      .querySelector(`:nth-child(${currentPage})`)
-      .setAttribute("class", "current-page")
+  let currentPage
+
+  function openPage(pageNumber) {
+    return function () {
+      productContainer.innerHTML = ""
+      currentPage = pageNumber
+      const productsForCurrentPage = productsArray.slice(
+        PRODUCTS_PER_PAGE * (currentPage - 1),
+        PRODUCTS_PER_PAGE * (currentPage - 1) + PRODUCTS_PER_PAGE
+      )
+      for (const product of productsForCurrentPage)
+        productContainer.appendChild(product)
+      paginationList
+        .querySelectorAll(":not(:last-child):not(:nth-last-child(2))")
+        .forEach((el) => el.removeAttribute("class"))
+      paginationList
+        .querySelector(`:nth-child(${currentPage})`)
+        .setAttribute("class", "current-page")
+    }
   }
+
+  for (let i = 1; i <= pageAmount; i++) {
+    const pageButton = document.createElement("span")
+    const pageNumber = document.createTextNode(i.toString())
+    pageButton.appendChild(pageNumber)
+    pageButton.addEventListener("click", openPage(i))
+    paginationList.appendChild(pageButton)
+  }
+
+  const nextPageButton = document.createElement("span")
+  const lastPageButton = document.createElement("span")
+
+  nextPageButton.appendChild(document.createTextNode("››"))
+  nextPageButton.setAttribute("class", "icon")
+  nextPageButton.addEventListener("click", function () {
+    currentPage < pageAmount && openPage(currentPage + 1)()
+  })
+
+  lastPageButton.appendChild(document.createTextNode("Último »"))
+  lastPageButton.setAttribute("class", "last")
+  lastPageButton.addEventListener("click", openPage(pageAmount))
+
+  paginationList.appendChild(nextPageButton)
+  paginationList.appendChild(lastPageButton)
+
+  openPage(1)()
 }
 
-for (let i = 1; i <= pageAmount; i++) {
-  const pageButton = document.createElement("span")
-  const pageNumber = document.createTextNode(i.toString())
-  pageButton.appendChild(pageNumber)
-  pageButton.addEventListener("click", openPage(i))
-  pageButtonList.appendChild(pageButton)
+const categoryNames = []
+const brandNames = []
+const activeFilters = {
+  categories: [],
+  brands: [],
 }
 
-const nextPageButton = document.createElement("span")
-const lastPageButton = document.createElement("span")
+for (const {
+  dataset: {categories, brands},
+} of productContainer.children) {
+  categories?.length && categoryNames.push(...categories.split(/ /))
+  brands?.length && brandNames.push(...brands.split(/ /))
+}
 
-nextPageButton.appendChild(document.createTextNode("››"))
-nextPageButton.setAttribute("class", "icon")
-nextPageButton.addEventListener("click", function () {
-  currentPage < pageAmount && openPage(currentPage + 1)()
-})
+function filter({target}) {
+  const [filterType, filterValue] = target.name.split(/-/)
 
-lastPageButton.appendChild(document.createTextNode("Último »"))
-lastPageButton.setAttribute("class", "last")
-lastPageButton.addEventListener("click", openPage(pageAmount))
+  target.checked
+    ? activeFilters[filterType].push(filterValue)
+    : activeFilters[filterType].splice(
+        activeFilters[filterType].indexOf(filterValue),
+        1
+      )
 
-pageButtonList.appendChild(nextPageButton)
-pageButtonList.appendChild(lastPageButton)
+  productContainer.innerHTML = ""
 
-openPage(1)()
+  if (!activeFilters.categories.length && !activeFilters.brands.length)
+    for (const product of Object.values(productStore))
+      productContainer.appendChild(product)
+  else {
+    const matchingProducts = Object.values(productStore).filter(({dataset}) =>
+      dataset.categories
+        ?.split(/ /)
+        .some(
+          (category) =>
+            activeFilters.categories.includes(category) ||
+            dataset.brands
+              ?.split(/ /)
+              .some((brand) => activeFilters.brands.includes(brand))
+        )
+    )
+    for (const matchingProduct of matchingProducts) {
+      productContainer.appendChild(matchingProduct)
+    }
+  }
+  paginate()
+}
+
+function createFilterCheckbox(type, name) {
+  const listItem = document.createElement("li")
+  listItem.dataset[type] = name
+  const input = document.createElement("input")
+  input.setAttribute("type", "checkbox")
+  input.setAttribute("name", `${type}-${name}`)
+  input.setAttribute("id", input.name)
+  input.addEventListener("click", filter)
+  const label = document.createElement("label")
+  label.setAttribute("for", input.name)
+  const span = document.createElement("span")
+  span.appendChild(document.createTextNode(name))
+  const small = document.createElement("small")
+  small.appendChild(
+    document.createTextNode(
+      `(${
+        Array.from(productContainer.children).filter(({dataset}) =>
+          dataset[type]?.split(/ /).includes(name)
+        ).length
+      })`
+    )
+  )
+  label.appendChild(span)
+  label.appendChild(small)
+  listItem.appendChild(input)
+  listItem.appendChild(label)
+  return listItem
+}
+
+for (const categoryName of categoryNames) {
+  categoryList.appendChild(createFilterCheckbox("categories", categoryName))
+}
+
+for (const brandName of brandNames) {
+  brandList.appendChild(createFilterCheckbox("brands", brandName))
+}
+
+paginate()

--- a/products.html
+++ b/products.html
@@ -65,127 +65,13 @@
             <div class="block-title">
               <h3>Categorías</h3>
             </div>
-            <ul class="block-content">
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Abrasivos</span>
-                  <small>(10)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Sólidos</span>
-                  <small>(7)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span> Soldadura</span>
-                  <small>(3)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Herramientas</span>
-                  <small>(3)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Cepillos de Alambre</span>
-                  <small>(10)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Productos de Lija</span>
-                  <small>(5)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Productos de Diamante</span>
-                  <small>(3)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Productos de Fibra</span>
-                  <small>(12)</small>
-                </label>
-              </li>
-            </ul>
+            <ul id="category-list" class="block-content"></ul>
           </div>
           <div>
             <div class="block-title">
               <h3>Marcas</h3>
             </div>
-            <ul class="block-content">
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Austromex</span>
-                  <small>(10)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Cinasa</span>
-                  <small>(7)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span> Maxtools</span>
-                  <small>(3)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Hecort</span>
-                  <small>(3)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Weston</span>
-                  <small>(3)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Makita</span>
-                  <small>(3)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Tulmex</span>
-                  <small>(3)</small>
-                </label>
-              </li>
-              <li>
-                <input type="checkbox" name="" id="">
-                <label for="">
-                  <span>Tuk</span>
-                  <small>(3)</small>
-                </label>
-              </li>
-            </ul>
+            <ul id="brand-list" class="block-content"></ul>
           </div>
         </div>
         <div class="col-3-of-4">
@@ -208,8 +94,13 @@
             </div>
             <a href="">Aplicar</a>
           </form>
-          <div class="product-layout">
-            <div class="product">
+          <div id="product-container" class="product-layout">
+            <!-- @TODO add categories and brands to other products like this -->
+            <div
+              data-categories="Cat1 Cat2"
+              data-brands="Brand1 Brand2"
+              class="product"
+            >
               <div class="img-container">
                 <img src="./images/Productos/product-1.png" alt="" />
               </div>
@@ -331,8 +222,7 @@
             </div>
           </div>
           <!-- PAGINATION -->
-          <ul class="pagination">
-          </ul>
+          <ul id="pagination-list" class="pagination"></ul>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Add functionality to product filter checkboxes.

# Usage
Add `data-categories` and `data-brands` attributes to the wrapper `<div>` of every product that should appear in filters. Add as many filter names to the attributes as needed by separating them with spaces, e.g. `data-categories="Category1 Category2"`.

**IMPORTANT:** If a product should only have one of the 2 filter types (categories or brands), add the other attribute anyway and leave its value empty, e.g. `data-brands=""`. 

# Operation logic
1. generate category and brand checkboxes for every unique `data-categories` and `data-brands` attribute entry respectively
2. add checkboxes to DOM in alphabetical order
3. when no checkboxes are active, all products are shown
4. when one or multiple checkboxes of the same type are active, all products matching **any** of the active filters are shown
5. when checkboxes across both types are active, only products matching **both** category and brand are shown
6. after every filter update the pagination is re-run